### PR TITLE
Fix RT Camera OnRemove detection

### DIFF
--- a/lua/entities/gmod_wire_rt_camera.lua
+++ b/lua/entities/gmod_wire_rt_camera.lua
@@ -85,12 +85,10 @@ if CLIENT then
         SetCameraActive(self, isActive)
     end
 
-    function ENT:OnRemove()
-        timer.Simple( 0, function()
-            if not IsValid(self) then
-                SetCameraActive(self, false)
-            end
-        end)
+    function ENT:OnRemove(fullUpdate)
+        if not fullUpdate then
+            SetCameraActive(self, false)
+        end
     end
 
     function ENT:SetIsObserved(isObserved)


### PR DESCRIPTION
Currently `ObservedCamerasIndex` isn't fully cleared which can cause RT material leakage.

After talking with @stepa2 he localized the issue to be in OnRemove which this PR fixes.

This also fixes the console command `wire_rt_camera_recreate` erroring.
